### PR TITLE
Start removing channel related information from the client

### DIFF
--- a/baselib/src/baseengine.cpp
+++ b/baselib/src/baseengine.cpp
@@ -1130,8 +1130,6 @@ void BaseEngine::handleGetlistUpdateStatus(
     }
     else if (listname == "voicemails")
         emit updateVoiceMailStatus(xid);
-    else if (listname == "channels")
-        emit updateChannelStatus(xid);
 }
 
 void BaseEngine::requestListConfig(const QString &listname, const QString &ipbxid, const QStringList &listid)

--- a/baselib/src/baseengine.h
+++ b/baselib/src/baseengine.h
@@ -287,7 +287,6 @@ class BASELIB_EXPORT BaseEngine: public QObject
         void updateQueueStatus(const QString &);
         void updateVoiceMailConfig(const QString &);
         void updateVoiceMailStatus(const QString &);
-        void updateChannelStatus(const QString &);
         void updateQueueMemberConfig(const QString &);
         void removePhoneConfig(const QString &);
         void removeUserConfig(const QString &);

--- a/baselib/src/storage/channelinfo.cpp
+++ b/baselib/src/storage/channelinfo.cpp
@@ -34,7 +34,6 @@ ChannelInfo::ChannelInfo(const QString & ipbxid,
                          const QString & id)
     : XInfo(ipbxid, id),
       m_timestamp(0.0),
-      m_linenumber(0),
       m_isholded(false)
 {
 }
@@ -70,11 +69,6 @@ const QString & ChannelInfo::commstatus() const
 double ChannelInfo::timestamp() const
 {
     return m_timestamp;
-}
-
-int ChannelInfo::linenumber() const
-{
-    return m_linenumber;
 }
 
 bool ChannelInfo::isholded() const

--- a/baselib/src/storage/channelinfo.cpp
+++ b/baselib/src/storage/channelinfo.cpp
@@ -42,7 +42,6 @@ ChannelInfo::ChannelInfo(const QString & ipbxid,
 bool ChannelInfo::updateStatus(const QVariantMap & prop)
 {
     bool haschanged = false;
-    haschanged |= setIfChangeString(prop, "direction", & m_direction);
     haschanged |= setIfChangeString(prop, "talkingto_kind", & m_talkingto_kind);
     haschanged |= setIfChangeString(prop, "talkingto_id", & m_talkingto_id);
     haschanged |= setIfChangeString(prop, "commstatus", & m_commstatus);
@@ -61,11 +60,6 @@ const QString & ChannelInfo::talkingto_kind() const
 const QString & ChannelInfo::talkingto_id() const
 {
     return m_talkingto_id;
-}
-
-const QString & ChannelInfo::direction() const
-{
-    return m_direction;
 }
 
 const QString & ChannelInfo::commstatus() const

--- a/baselib/src/storage/channelinfo.h
+++ b/baselib/src/storage/channelinfo.h
@@ -43,7 +43,6 @@ class BASELIB_EXPORT ChannelInfo : public XInfo
         const QString & talkingto_id() const;
         const QString & commstatus() const;
         double timestamp() const;
-        int linenumber() const;
         bool isholded() const;
         bool canBeTransferred() const;
         bool isTalking() const;
@@ -56,7 +55,6 @@ class BASELIB_EXPORT ChannelInfo : public XInfo
         QString m_state;
         double m_timestamp;
 
-        int m_linenumber;
         bool m_isholded;
 };
 

--- a/baselib/src/storage/channelinfo.h
+++ b/baselib/src/storage/channelinfo.h
@@ -41,7 +41,6 @@ class BASELIB_EXPORT ChannelInfo : public XInfo
 
         const QString & talkingto_kind() const;
         const QString & talkingto_id() const;
-        const QString & direction() const;
         const QString & commstatus() const;
         double timestamp() const;
         int linenumber() const;
@@ -51,7 +50,6 @@ class BASELIB_EXPORT ChannelInfo : public XInfo
 
     private:
 
-        QString m_direction;
         QString m_commstatus;
         QString m_talkingto_kind;
         QString m_talkingto_id;

--- a/xivoclient/src/xlets/identity/identity.cpp
+++ b/xivoclient/src/xlets/identity/identity.cpp
@@ -298,8 +298,6 @@ void IdentityDisplay::updateUserConfig(const QString & xuserid)
                     m_identityphones[xphoneid], SLOT(updatePhoneConfig(const QString &)));
             connect(b_engine, SIGNAL(updatePhoneStatus(const QString &)),
                     m_identityphones[xphoneid], SLOT(updatePhoneStatus(const QString &)));
-            connect(b_engine, SIGNAL(updateChannelStatus(const QString &)),
-                    m_identityphones[xphoneid], SLOT(updateChannelStatus(const QString &)));
             m_glayout->addWidget(m_identityphones[xphoneid], 0, m_col_phone ++, 3, 1);
         }
         m_identityphones[xphoneid]->setPhoneId(xphoneid);

--- a/xivoclient/src/xlets/identity/identityphone.cpp
+++ b/xivoclient/src/xlets/identity/identityphone.cpp
@@ -79,13 +79,6 @@ void IdentityPhone::setPhoneId(const QString & xphoneid)
     m_xphoneid = xphoneid;
 }
 
-void IdentityPhone::updateChannelStatus(const QString & xchannelid)
-{
-    const ChannelInfo * channelinfo = b_engine->channels().value(xchannelid);
-    if (channelinfo == NULL)
-        return;
-}
-
 void IdentityPhone::updatePhoneConfig(const QString & xphoneid)
 {
     if (xphoneid != m_xphoneid)

--- a/xivoclient/src/xlets/identity/identityphone.h
+++ b/xivoclient/src/xlets/identity/identityphone.h
@@ -51,7 +51,6 @@ class IdentityPhone : public QWidget
     public slots:
         void updatePhoneConfig(const QString &);
         void updatePhoneStatus(const QString &);
-        void updateChannelStatus(const QString &);
     private:
         void setPhoneLines();
         QString m_xphoneid;


### PR DESCRIPTION
remove the updateChannelStatus signal that is now unused
remove the linenumber and direction properties of a ChannelInfo since they are unused